### PR TITLE
Add setting to fit background-image to slide

### DIFF
--- a/includes/slide-renderer.php
+++ b/includes/slide-renderer.php
@@ -45,6 +45,7 @@ function render_sliderberg_slide_block($attributes, $content, $block) {
     $min_height = max(100, min(1000, intval($attributes['minHeight'] ?? 400)));
     $content_position = sanitize_text_field($attributes['contentPosition'] ?? 'center-center');
     $is_fixed = (bool)($attributes['isFixed'] ?? false);
+    $is_contained = (bool)($attributes['isContained'] ?? false);
     
     // Validate content position
     $valid_positions = [
@@ -76,7 +77,8 @@ function render_sliderberg_slide_block($attributes, $content, $block) {
             $focal_x = max(0, min(1, floatval($focal_point['x'] ?? 0.5))) * 100;
             $focal_y = max(0, min(1, floatval($focal_point['y'] ?? 0.5))) * 100;
             $styles[] = 'background-position: ' . esc_attr($focal_x) . '% ' . esc_attr($focal_y) . '%';
-            $styles[] = 'background-size: cover';
+            $styles[] = 'background-size: ' . ($is_contained ? 'contain' : 'cover');
+            $styles[] = 'background-repeat: no-repeat';
             $styles[] = 'background-attachment: ' . ($is_fixed ? 'fixed' : 'scroll');
         }
     } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sliderberg",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A modern slider block for WordPress block editor",
   "author": "DotCamp",
   "license": "GPL-2.0-or-later",

--- a/sliderberg.php
+++ b/sliderberg.php
@@ -3,7 +3,7 @@
  * Plugin Name: Sliderberg
  * Plugin URI: https://sliderberg.com/
  * Description: Slider Block For the Block Editor (Gutenberg). Slide Anything With Ease.
- * Version: 1.0.2
+ * Version: 1.0.3
  * Author: DotCamp
  * Author URI: https://dotcamp.com/
  * License: GPL v2 or later

--- a/sliderberg.php
+++ b/sliderberg.php
@@ -18,7 +18,7 @@ if (!defined('WPINC')) {
 }
 
 // Define plugin constants
-define('SLIDERBERG_VERSION', '1.0.2');
+define('SLIDERBERG_VERSION', '1.0.3');
 define('SLIDERBERG_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('SLIDERBERG_PLUGIN_URL', plugin_dir_url(__FILE__));
 

--- a/src/blocks/slide/editor.css
+++ b/src/blocks/slide/editor.css
@@ -9,6 +9,7 @@
     margin: 1rem 0;
     display: flex;
     flex-direction: column;
+    background-repeat: no-repeat;
 }
 
 /* Remove border and styling for posts slider type */

--- a/src/blocks/slide/index.tsx
+++ b/src/blocks/slide/index.tsx
@@ -177,7 +177,7 @@ registerBlockType( 'sliderberg/slide', {
 		},
 		isContained: {
 			type: 'boolean',
-			default: true,
+			default: false,
 		},
 	},
 	edit: ( props: {
@@ -438,7 +438,7 @@ registerBlockType( 'sliderberg/slide', {
 								/>
 								<ToggleControl
 									label={ __(
-										'Contain whole image',
+										'Fit background image to slide',
 										'sliderberg'
 									) }
 									checked={ isContained }

--- a/src/blocks/slide/index.tsx
+++ b/src/blocks/slide/index.tsx
@@ -64,6 +64,7 @@ interface SlideAttributes {
 		| 'bottom-center'
 		| 'bottom-right';
 	isFixed: boolean;
+	isContained: boolean;
 }
 
 const ALLOWED_BLOCKS = [
@@ -174,6 +175,10 @@ registerBlockType( 'sliderberg/slide', {
 			type: 'boolean',
 			default: false,
 		},
+		isContained: {
+			type: 'boolean',
+			default: true,
+		},
 	},
 	edit: ( props: {
 		attributes: SlideAttributes;
@@ -192,6 +197,7 @@ registerBlockType( 'sliderberg/slide', {
 			minHeight,
 			contentPosition,
 			isFixed,
+			isContained
 		} = attributes;
 
 		// Get theme color palette
@@ -241,7 +247,7 @@ registerBlockType( 'sliderberg/slide', {
 								50
 						  ) }%`
 						: 'center',
-				backgroundSize: 'cover',
+				backgroundSize: isContained ? 'contain' : 'cover',
 				backgroundAttachment: isFixed ? 'fixed' : 'scroll',
 			},
 			'data-client-id': clientId,
@@ -428,6 +434,16 @@ registerBlockType( 'sliderberg/slide', {
 									checked={ isFixed }
 									onChange={ ( value ) =>
 										setAttributes( { isFixed: value } )
+									}
+								/>
+								<ToggleControl
+									label={ __(
+										'Contain whole image',
+										'sliderberg'
+									) }
+									checked={ isContained }
+									onChange={ ( value ) =>
+										setAttributes( { isContained: value } )
 									}
 								/>
 								<div className="sliderberg-focal-point-picker">

--- a/src/blocks/slide/style.css
+++ b/src/blocks/slide/style.css
@@ -7,6 +7,7 @@
     display: flex;
     flex-direction: column;
     height: 100%;
+    background-repeat:no-repeat;
 }
 
 .sliderberg-overlay {

--- a/src/types/slide.ts
+++ b/src/types/slide.ts
@@ -29,6 +29,7 @@ export interface SlideAttributes {
 	minHeight: number;
 	contentPosition: ContentPosition;
 	isFixed: boolean;
+	isContained: boolean;
 }
 
 export interface SlideEditProps {


### PR DESCRIPTION
When a background image is too large, it is cut of. This setting gives the user an option to reduce (or expand) the image to the slide-container.